### PR TITLE
JSON Schema OneOf Support

### DIFF
--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -292,11 +292,6 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 				subSchema.Value.Schema = nil
 				subSchema.Name = messageDefinitionName(subMessage.Desc)
 
-				//if subSchema.Value.Definitions != nil {
-				//	*schema.Value.Definitions = append(*schema.Value.Definitions, *subSchema.Value.Definitions...)
-				//	subSchema.Value.Definitions = nil
-				//}
-
 				schemas = append(schemas, subSchemas...)
 			}
 		}

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -37,6 +37,7 @@ var (
 	typeBoolean = "boolean"
 	typeObject  = "object"
 	typeArray   = "array"
+	typeNull    = "null"
 
 	formatDate     = "date"
 	formatDateTime = "date-time"
@@ -97,20 +98,7 @@ func (g *JSONSchemaGenerator) Run() error {
 		}
 	}
 
-	g.generateTypeUnspecified()
-
 	return nil
-}
-
-func (g *JSONSchemaGenerator) generateTypeUnspecified() {
-	unspecifiedSchema := g.setupSchemaForMessage("TypeUnspecified", "")
-	kindProperty := g.buildKindProperty("unspecified")
-	*unspecifiedSchema.Value.Properties = append(
-		*unspecifiedSchema.Value.Properties,
-		kindProperty,
-	)
-	outputFile := g.plugin.NewGeneratedFile(fmt.Sprintf("%s.json", unspecifiedSchema.Name), "")
-	outputFile.Write([]byte(unspecifiedSchema.Value.JSONString()))
 }
 
 // filterCommentString removes line breaks and linter rules from comments.
@@ -393,11 +381,11 @@ func (g *JSONSchemaGenerator) addOneofFieldsToSchema(oneofs []*protogen.Oneof, s
 
 	for _, oneOfProto := range oneofs {
 		oneOfSchema := jsonschema.Schema{
-			OneOf: &[]*jsonschema.Schema{},
+			OneOf:   &[]*jsonschema.Schema{},
+			Default: &jsonschema.DefaultValue{NullTag: true},
 		}
 
-		refUnspecified := "TypeUnspecified.json"
-		*oneOfSchema.OneOf = append(*oneOfSchema.OneOf, &jsonschema.Schema{Ref: &refUnspecified})
+		*oneOfSchema.OneOf = append(*oneOfSchema.OneOf, &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeNull}})
 
 		for _, fieldProto := range oneOfProto.Fields {
 			ref := schema.Name + "_" + fieldProto.GoName

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -325,7 +325,7 @@ func (g *JSONSchemaGenerator) namedSchemaForField(field *protogen.Field, schema 
 	}
 
 	fieldName := "value"
-	if isValueProp {
+	if !isValueProp {
 		fieldName = g.formatFieldName(field)
 	}
 

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -260,7 +260,7 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 
 	// For each message, generate a schema.
 	for _, message := range messages {
-		schemaName := string(message.Desc.Name())
+		schemaName := messageDefinitionName(message.Desc)
 		typ := "object"
 		id := fmt.Sprintf("%s%s.json", *g.conf.BaseURL, schemaName)
 
@@ -284,14 +284,6 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 		if message.Messages != nil {
 			for _, subMessage := range message.Messages {
 				subSchemas := g.buildSchemasFromMessages([]*protogen.Message{subMessage})
-				if len(subSchemas) != 1 {
-					continue
-				}
-				subSchema := subSchemas[0]
-				subSchema.Value.ID = nil
-				subSchema.Value.Schema = nil
-				subSchema.Name = messageDefinitionName(subMessage.Desc)
-
 				schemas = append(schemas, subSchemas...)
 			}
 		}

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -359,9 +359,11 @@ func (g *JSONSchemaGenerator) setupSchemaForMessage(schemaName string, comments 
 }
 
 func (g *JSONSchemaGenerator) buildKindProperty(propertyValue string) *jsonschema.NamedSchema {
+	kind := "kind"
 	kindProperty := &jsonschema.NamedSchema{
-		Name: "kind",
+		Name: kind,
 		Value: &jsonschema.Schema{
+			Title:       &kind,
 			Type:        &jsonschema.StringOrStringArray{String: &typeString},
 			Enumeration: &[]jsonschema.SchemaEnumValue{},
 			Default:     &jsonschema.DefaultValue{StringValue: &propertyValue},

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -230,7 +230,7 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 				name := string(field.Enum().Values().Get(i).Name())
 				*kindSchema.Enumeration = append(*kindSchema.Enumeration, jsonschema.SchemaEnumValue{String: &name})
 				if i == 0 {
-					kindSchema.Default = &jsonschema.DefaultValue{StringValue: &emptyString}
+					kindSchema.Default = &jsonschema.DefaultValue{StringValue: &name}
 				}
 			}
 		} else {

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -104,10 +104,10 @@ func (g *JSONSchemaGenerator) Run() error {
 
 func (g *JSONSchemaGenerator) generateTypeUnspecified() {
 	unspecifiedSchema := g.setupSchemaForMessage("TypeUnspecified", "")
-	typeOfObjectProperty := g.buildTypeOfObjectProperty("unspecified")
+	kindProperty := g.buildKindProperty("unspecified")
 	*unspecifiedSchema.Value.Properties = append(
 		*unspecifiedSchema.Value.Properties,
-		typeOfObjectProperty,
+		kindProperty,
 	)
 	outputFile := g.plugin.NewGeneratedFile(fmt.Sprintf("%s.json", unspecifiedSchema.Name), "")
 	outputFile.Write([]byte(unspecifiedSchema.Value.JSONString()))
@@ -366,20 +366,20 @@ func (g *JSONSchemaGenerator) setupSchemaForMessage(schemaName string, comments 
 	return schema
 }
 
-func (g *JSONSchemaGenerator) buildTypeOfObjectProperty(propertyValue string) *jsonschema.NamedSchema {
-	typeOfObjectProperty := &jsonschema.NamedSchema{
-		Name: "typeOfObject",
+func (g *JSONSchemaGenerator) buildKindProperty(propertyValue string) *jsonschema.NamedSchema {
+	kindProperty := &jsonschema.NamedSchema{
+		Name: "kind",
 		Value: &jsonschema.Schema{
 			Type:        &jsonschema.StringOrStringArray{String: &typeString},
 			Enumeration: &[]jsonschema.SchemaEnumValue{},
 			Default:     &jsonschema.DefaultValue{StringValue: &propertyValue},
 		},
 	}
-	*typeOfObjectProperty.Value.Enumeration = append(
-		*typeOfObjectProperty.Value.Enumeration,
+	*kindProperty.Value.Enumeration = append(
+		*kindProperty.Value.Enumeration,
 		jsonschema.SchemaEnumValue{String: &propertyValue},
 	)
-	return typeOfObjectProperty
+	return kindProperty
 }
 
 func (g *JSONSchemaGenerator) addOneofFieldsToSchema(oneofs []*protogen.Oneof, schema *jsonschema.NamedSchema) {
@@ -405,7 +405,7 @@ func (g *JSONSchemaGenerator) addOneofFieldsToSchema(oneofs []*protogen.Oneof, s
 					Properties: &[]*jsonschema.NamedSchema{},
 				},
 			}
-			typeOfObjectProperty := g.buildTypeOfObjectProperty(string(fieldProto.Desc.Name()))
+			kindProperty := g.buildKindProperty(string(fieldProto.Desc.Name()))
 			actualProperty := g.namedSchemaForField(fieldProto, schema)
 			if actualProperty == nil {
 				continue
@@ -413,7 +413,7 @@ func (g *JSONSchemaGenerator) addOneofFieldsToSchema(oneofs []*protogen.Oneof, s
 
 			*oneofFieldSchema.Value.Properties = append(
 				*oneofFieldSchema.Value.Properties,
-				typeOfObjectProperty,
+				kindProperty,
 				actualProperty,
 			)
 

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"gopkg.in/yaml.v3"
 
 	"github.com/google/gnostic/jsonschema"
 )
@@ -46,6 +47,7 @@ var (
 	emptyInt64   = int64(0)
 	emptyFloat64 = 0.0
 	emptyBoolean = false
+	emptyArray   = []*yaml.Node{}
 )
 
 func init() {
@@ -227,9 +229,13 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 			for i := 0; i < field.Enum().Values().Len(); i++ {
 				name := string(field.Enum().Values().Get(i).Name())
 				*kindSchema.Enumeration = append(*kindSchema.Enumeration, jsonschema.SchemaEnumValue{String: &name})
+				if i == 0 {
+					kindSchema.Default = &jsonschema.DefaultValue{StringValue: &emptyString}
+				}
 			}
 		} else {
 			kindSchema.Type = &jsonschema.StringOrStringArray{String: &typeInteger}
+			kindSchema.Default = &jsonschema.DefaultValue{Int64Value: &emptyInt64}
 		}
 
 	case protoreflect.BoolKind:
@@ -253,6 +259,7 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 			Items: &jsonschema.SchemaOrSchemaArray{
 				Schema: kindSchema,
 			},
+			Default: &jsonschema.DefaultValue{ArrayValue: emptyArray},
 		}
 	}
 

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -177,7 +177,7 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForType(desc protoreflect.Message
 	}
 
 	typeName = messageDefinitionName(desc)
-	ref := "#/definitions/" + g.formatMessageNameString(typeName)
+	ref := g.formatMessageNameString(typeName) + ".json"
 	return &jsonschema.Schema{Ref: &ref}
 }
 
@@ -202,14 +202,6 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 		kindSchema = g.schemaOrReferenceForType(field.Message())
 		if kindSchema == nil {
 			return nil
-		}
-
-		if kindSchema.Ref != nil {
-			if !refInDefinitions(*kindSchema.Ref, definitions) {
-				ref := strings.Replace(*kindSchema.Ref, "#/definitions/", *g.conf.BaseURL, 1)
-				ref += ".json"
-				kindSchema.Ref = &ref
-			}
 		}
 
 	case protoreflect.StringKind:
@@ -288,12 +280,8 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 			schema.Value.Description = &description
 		}
 
-		// Any embedded messages will be created as definitions
+		// Any embedded messages will be created as new schemas
 		if message.Messages != nil {
-			if schema.Value.Definitions == nil {
-				schema.Value.Definitions = &[]*jsonschema.NamedSchema{}
-			}
-
 			for _, subMessage := range message.Messages {
 				subSchemas := g.buildSchemasFromMessages([]*protogen.Message{subMessage})
 				if len(subSchemas) != 1 {
@@ -304,12 +292,12 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 				subSchema.Value.Schema = nil
 				subSchema.Name = messageDefinitionName(subMessage.Desc)
 
-				if subSchema.Value.Definitions != nil {
-					*schema.Value.Definitions = append(*schema.Value.Definitions, *subSchema.Value.Definitions...)
-					subSchema.Value.Definitions = nil
-				}
+				//if subSchema.Value.Definitions != nil {
+				//	*schema.Value.Definitions = append(*schema.Value.Definitions, *subSchema.Value.Definitions...)
+				//	subSchema.Value.Definitions = nil
+				//}
 
-				*schema.Value.Definitions = append(*schema.Value.Definitions, subSchemas...)
+				schemas = append(schemas, subSchemas...)
 			}
 		}
 
@@ -382,17 +370,4 @@ func getSchemaVersion(schema *jsonschema.Schema) string {
 		return matches[1]
 	}
 	return ""
-}
-
-func refInDefinitions(ref string, definitions *[]*jsonschema.NamedSchema) bool {
-	if definitions == nil {
-		return false
-	}
-	ref = strings.TrimPrefix(ref, "#/definitions/")
-	for _, def := range *definitions {
-		if ref == def.Name {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -41,6 +41,11 @@ var (
 	formatDateTime = "date-time"
 	formatEnum     = "enum"
 	formatBytes    = "bytes"
+
+	emptyString  = ""
+	emptyInt64   = int64(0)
+	emptyFloat64 = 0.0
+	emptyBoolean = false
 )
 
 func init() {
@@ -205,14 +210,14 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 		}
 
 	case protoreflect.StringKind:
-		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeString}}
+		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeString}, Default: &jsonschema.DefaultValue{StringValue: &emptyString}}
 
 	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Uint32Kind,
 		protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
 		protoreflect.Sfixed32Kind, protoreflect.Fixed32Kind, protoreflect.Sfixed64Kind,
 		protoreflect.Fixed64Kind:
 		format := kind.String()
-		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeInteger}, Format: &format}
+		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeInteger}, Format: &format, Default: &jsonschema.DefaultValue{Int64Value: &emptyInt64}}
 
 	case protoreflect.EnumKind:
 		kindSchema = &jsonschema.Schema{Format: &formatEnum}
@@ -228,14 +233,14 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 		}
 
 	case protoreflect.BoolKind:
-		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeBoolean}}
+		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeBoolean}, Default: &jsonschema.DefaultValue{BooleanValue: &emptyBoolean}}
 
 	case protoreflect.FloatKind, protoreflect.DoubleKind:
 		format := kind.String()
-		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeNumber}, Format: &format}
+		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeNumber}, Format: &format, Default: &jsonschema.DefaultValue{Float64Value: &emptyFloat64}}
 
 	case protoreflect.BytesKind:
-		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeString}, Format: &formatBytes}
+		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeString}, Format: &formatBytes, Default: &jsonschema.DefaultValue{StringValue: &emptyString}}
 
 	default:
 		log.Printf("(TODO) Unsupported field type: %+v", field.Message().FullName())

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -409,8 +409,7 @@ func (g *JSONSchemaGenerator) addOneofFieldsToSchema(oneofs []*protogen.Oneof, s
 					Properties: &[]*jsonschema.NamedSchema{},
 				},
 			}
-			kindPropertyValue := "type_" + string(fieldProto.Desc.Name())
-			kindProperty := g.buildKindProperty(kindPropertyValue)
+			kindProperty := g.buildKindProperty(string(fieldProto.Desc.Name()))
 			actualProperty := g.namedSchemaForField(fieldProto, schema, true)
 			if actualProperty == nil {
 				continue

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -409,7 +409,8 @@ func (g *JSONSchemaGenerator) addOneofFieldsToSchema(oneofs []*protogen.Oneof, s
 					Properties: &[]*jsonschema.NamedSchema{},
 				},
 			}
-			kindProperty := g.buildKindProperty(string(fieldProto.Desc.Name()))
+			kindPropertyValue := "type_" + string(fieldProto.Desc.Name())
+			kindProperty := g.buildKindProperty(kindPropertyValue)
 			actualProperty := g.namedSchemaForField(fieldProto, schema, true)
 			if actualProperty == nil {
 				continue

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -296,7 +296,7 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 	return kindSchema
 }
 
-func (g *JSONSchemaGenerator) namedSchemaForField(field *protogen.Field, schema *jsonschema.NamedSchema) *jsonschema.NamedSchema {
+func (g *JSONSchemaGenerator) namedSchemaForField(field *protogen.Field, schema *jsonschema.NamedSchema, isValueProp bool) *jsonschema.NamedSchema {
 	// The field is either described by a reference or a schema.
 	fieldSchema := g.schemaOrReferenceForField(field.Desc, schema.Value.Definitions)
 	if fieldSchema == nil {
@@ -324,7 +324,11 @@ func (g *JSONSchemaGenerator) namedSchemaForField(field *protogen.Field, schema 
 		}
 	}
 
-	fieldName := g.formatFieldName(field)
+	fieldName := "value"
+	if isValueProp {
+		fieldName = g.formatFieldName(field)
+	}
+
 	// Do not add title for ref values
 	if fieldSchema.Ref == nil {
 		fieldSchema.Title = &fieldName
@@ -406,7 +410,7 @@ func (g *JSONSchemaGenerator) addOneofFieldsToSchema(oneofs []*protogen.Oneof, s
 				},
 			}
 			kindProperty := g.buildKindProperty(string(fieldProto.Desc.Name()))
-			actualProperty := g.namedSchemaForField(fieldProto, schema)
+			actualProperty := g.namedSchemaForField(fieldProto, schema, true)
 			if actualProperty == nil {
 				continue
 			}
@@ -464,7 +468,7 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 				continue
 			}
 
-			namedSchema := g.namedSchemaForField(field, schema)
+			namedSchema := g.namedSchemaForField(field, schema, false)
 			if namedSchema == nil {
 				continue
 			}

--- a/jsonschema/models.go
+++ b/jsonschema/models.go
@@ -235,4 +235,5 @@ type DefaultValue struct {
 	Int64Value   *int64
 	Float64Value *float64
 	ArrayValue   []*yaml.Node
+	NullTag      bool
 }

--- a/jsonschema/models.go
+++ b/jsonschema/models.go
@@ -16,8 +16,6 @@
 // of JSON Schemas.
 package jsonschema
 
-import "gopkg.in/yaml.v3"
-
 // The Schema struct models a JSON Schema and, because schemas are
 // defined hierarchically, contains many references to itself.
 // All fields are pointers and are nil if the associated values
@@ -70,7 +68,7 @@ type Schema struct {
 	// 6.  Metadata keywords
 	Title       *string
 	Description *string
-	Default     *yaml.Node
+	Default     *DefaultValue
 
 	// 7.  Semantic validation with "format"
 	Format *string
@@ -227,4 +225,11 @@ func (s *Schema) DefinitionWithName(name string) *Schema {
 // AddProperty adds a named property.
 func (s *Schema) AddProperty(name string, property *Schema) {
 	*s.Properties = append(*s.Properties, NewNamedSchema(name, property))
+}
+
+type DefaultValue struct {
+	StringValue  *string
+	BooleanValue *bool
+	Int64Value   *int64
+	Float64Value *float64
 }

--- a/jsonschema/models.go
+++ b/jsonschema/models.go
@@ -16,6 +16,8 @@
 // of JSON Schemas.
 package jsonschema
 
+import "gopkg.in/yaml.v3"
+
 // The Schema struct models a JSON Schema and, because schemas are
 // defined hierarchically, contains many references to itself.
 // All fields are pointers and are nil if the associated values
@@ -232,4 +234,5 @@ type DefaultValue struct {
 	BooleanValue *bool
 	Int64Value   *int64
 	Float64Value *float64
+	ArrayValue   []*yaml.Node
 }

--- a/jsonschema/reader.go
+++ b/jsonschema/reader.go
@@ -143,7 +143,7 @@ func NewSchemaFromObject(jsonData *yaml.Node) *Schema {
 				schema.Description = schema.stringValue(v)
 
 			case "default":
-				schema.Default = v
+				schema.Default = schema.defaultValue(v)
 
 			case "format":
 				schema.Format = schema.stringValue(v)
@@ -244,6 +244,28 @@ func (schema *Schema) boolValue(v *yaml.Node) *bool {
 		}
 	default:
 		fmt.Printf("boolValue: unexpected node %+v\n", v)
+	}
+	return nil
+}
+
+func (schema *Schema) defaultValue(v *yaml.Node) *DefaultValue {
+	switch v.Kind {
+	case yaml.ScalarNode:
+		switch v.Tag {
+		case "!!float":
+			v2, _ := strconv.ParseFloat(v.Value, 64)
+			return &DefaultValue{Float64Value: &v2}
+		case "!!int":
+			v2, _ := strconv.ParseInt(v.Value, 10, 64)
+			return &DefaultValue{Int64Value: &v2}
+		case "!!bool":
+			v2, _ := strconv.ParseBool(v.Value)
+			return &DefaultValue{BooleanValue: &v2}
+		default:
+			return &DefaultValue{StringValue: &v.Value}
+		}
+	default:
+		fmt.Printf("defaultValue: unexpected node %+v\n", v)
 	}
 	return nil
 }

--- a/jsonschema/reader.go
+++ b/jsonschema/reader.go
@@ -264,6 +264,8 @@ func (schema *Schema) defaultValue(v *yaml.Node) *DefaultValue {
 		default:
 			return &DefaultValue{StringValue: &v.Value}
 		}
+	case yaml.SequenceNode:
+		return &DefaultValue{ArrayValue: v.Content}
 	default:
 		fmt.Printf("defaultValue: unexpected node %+v\n", v)
 	}

--- a/jsonschema/reader.go
+++ b/jsonschema/reader.go
@@ -261,6 +261,8 @@ func (schema *Schema) defaultValue(v *yaml.Node) *DefaultValue {
 		case "!!bool":
 			v2, _ := strconv.ParseBool(v.Value)
 			return &DefaultValue{BooleanValue: &v2}
+		case "!!null":
+			return &DefaultValue{NullTag: true}
 		default:
 			return &DefaultValue{StringValue: &v.Value}
 		}

--- a/jsonschema/writer.go
+++ b/jsonschema/writer.go
@@ -385,6 +385,8 @@ func (schema *Schema) nodeValue() *yaml.Node {
 			content = appendPair(content, "default", nodeForInt64(*schema.Default.Int64Value))
 		} else if schema.Default.Float64Value != nil {
 			content = appendPair(content, "default", nodeForFloat64(*schema.Default.Float64Value))
+		} else if schema.Default.ArrayValue != nil {
+			content = appendPair(content, "default", nodeForSequence(schema.Default.ArrayValue))
 		}
 	}
 	if schema.Format != nil {

--- a/jsonschema/writer.go
+++ b/jsonschema/writer.go
@@ -34,7 +34,7 @@ func renderMappingNode(node *yaml.Node, indent string) (result string) {
 		value := node.Content[i+1]
 		switch value.Kind {
 		case yaml.ScalarNode:
-			if value.Tag == "!!bool" || value.Tag == "!!int" || value.Tag == "!!float" {
+			if value.Tag == "!!bool" || value.Tag == "!!int" || value.Tag == "!!float" || value.Tag == "!!null" {
 				result += value.Value
 			} else {
 				result += "\"" + value.Value + "\""
@@ -224,6 +224,14 @@ func nodeForSequence(content []*yaml.Node) *yaml.Node {
 	}
 }
 
+func nodeForNull() *yaml.Node {
+	return &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!null",
+		Value: "null",
+	}
+}
+
 func nodeForString(value string) *yaml.Node {
 	return &yaml.Node{
 		Kind:  yaml.ScalarNode,
@@ -387,6 +395,8 @@ func (schema *Schema) nodeValue() *yaml.Node {
 			content = appendPair(content, "default", nodeForFloat64(*schema.Default.Float64Value))
 		} else if schema.Default.ArrayValue != nil {
 			content = appendPair(content, "default", nodeForSequence(schema.Default.ArrayValue))
+		} else if schema.Default.NullTag {
+			content = appendPair(content, "default", nodeForNull())
 		}
 	}
 	if schema.Format != nil {

--- a/jsonschema/writer.go
+++ b/jsonschema/writer.go
@@ -34,7 +34,7 @@ func renderMappingNode(node *yaml.Node, indent string) (result string) {
 		value := node.Content[i+1]
 		switch value.Kind {
 		case yaml.ScalarNode:
-			if value.Tag == "!!bool" {
+			if value.Tag == "!!bool" || value.Tag == "!!int" || value.Tag == "!!float" {
 				result += value.Value
 			} else {
 				result += "\"" + value.Value + "\""
@@ -377,7 +377,15 @@ func (schema *Schema) nodeValue() *yaml.Node {
 		content = appendPair(content, "definitions", nodeForNamedSchemaArray(schema.Definitions))
 	}
 	if schema.Default != nil {
-		// m = append(m, yaml.MapItem{Key: "default", Value: *schema.Default})
+		if schema.Default.StringValue != nil {
+			content = appendPair(content, "default", nodeForString(*schema.Default.StringValue))
+		} else if schema.Default.BooleanValue != nil {
+			content = appendPair(content, "default", nodeForBoolean(*schema.Default.BooleanValue))
+		} else if schema.Default.Int64Value != nil {
+			content = appendPair(content, "default", nodeForInt64(*schema.Default.Int64Value))
+		} else if schema.Default.Float64Value != nil {
+			content = appendPair(content, "default", nodeForFloat64(*schema.Default.Float64Value))
+		}
 	}
 	if schema.Format != nil {
 		content = appendPair(content, "format", nodeForString(*schema.Format))


### PR DESCRIPTION
**To be merged after https://github.com/CamBDignan/gnostic/pull/3**

**Related issue:** https://github.com/google/gnostic/issues/251

Currently, the `oneof` specifier in proto messages is ignored in the translated JSON schema. For example, the following proto:

```proto
message Pet {
  oneof type_of_pet {
    string cat = 1;
    string dog = 2;
  }
}
```

will be translated to:

```json
{
  "title": "Pet",
  "$id": "Pet.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "cat": {
      "title": "cat",
      "type": "string",
      "default": ""
    },
    "dog": {
      "title": "dog",
      "type": "string",
      "default": ""
    }
  }
}
```

This is undesirable because then the following JSON would be considered valid:

```json
{
  "cat": "Whiskers",
  "dog": "Barky"
}
```

This PR attempts to maintain the spirit of protobuf `oneof` in JSON schema. In order to accomplish this goal, I thought about what we want a valid JSON to actually look like. Continuing with the `Pet` example above, the following could be considered valid:

```json
{
  "cat": "Whiskers"
}
```

or

```json
{
  "dog": "Barky"
}
```

For oneofs in protobuf, it is also possible that neither alternative in the oneof is specified, so maybe in JSON that would just be the following:

```json
{}
```

However, like I mentioned before, we are trying to maintain the spirit of the protobuf `oneof`. When consuming protobuf generated code, we do not check for the presence or absence of a field to determine which alternative is specified. Rather, we do a switch on some enum (in the `Pet` example, we would switch on `type_of_pet`). So maybe JSON that is closer in spirit to the protobuf would look more like the following:

```json
{
  "kind": "cat",
  "value": "Whiskers"
}
```

or

```json
{
  "kind": "dog",
  "value": "Barky"
}
```

(Null, or absence of a value, could still be used to represent "unspecified").

This seems to work pretty well - clients can always switch on the `kind` enum to determine the type of object they are dealing with. However, there is one more thing to consider - a single proto message can contain more than one `oneof`. Consider the following:

```proto
message DateTimeOffset {
  oneof local_date_time {
    sint64 local_epoch_ms = 1;
    DateTimeComponents date_time_components = 2;
  }

  oneof time_offset {
    sint64 utc_offset = 3;
  }
}
```

I realized in order to accommodate the above case, one more level of nesting would be necessary. See the following examples of valid JSON for the above proto for what I mean:

```json
{
  "localDateTime": {
    "kind": "local_epoch_ms",
    "value": 123
  },
  "timeOffset": {
    "kind": "utc_offset",
    "value": 9
  }
}
```

or

```json
{
  "localDateTime": {
    "kind": "date_time_components",
    "value": {
      // ...
    }
  },
  "timeOffset": {
    "kind": "utc_offset",
    "value": 9
  }
}
```

And its easy to see how this additional level of nesting would work for the `Pet` case as well:

```json
{
  "typeOfPet": {
    "kind": "cat",
    "value": "Whiskers"
  }
}
```

or

```json
{
  "typeOfPet": {
    "kind": "dog",
    "value": "Barky"
  }
}  
```

Now that we have an idea what valid JSON would look like, we can attempt to define the JSON schemas.

**Pet.json**

```json
{
  "title": "Pet",
  "$id": "Pet.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "typeOfPet": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/Pet_Cat"
        },
        {
          "$ref": "#/definitions/Pet_Dog"
        }
      ],
      "default": null
    }
  },
  "definitions": {
    "Pet_Cat": {
      "title": "Pet_Cat",
      "type": "object",
      "properties": {
        "kind": {
          "type": "string",
          "enum": [
            "cat"
          ],
          "default": "cat"
        },
        "value": {
          "title": "value",
          "type": "string",
          "default": ""
        }
      }
    },
    "Pet_Dog": {
      "title": "Pet_Dog",
      "type": "object",
      "properties": {
        "kind": {
          "type": "string",
          "enum": [
            "dog"
          ],
          "default": "dog"
        },
        "value": {
          "title": "value",
          "type": "string",
          "default": ""
        }
      }
    }
  }
}
```

**DateTimeOffset.json**

```json
{
  "title": "DateTimeOffset",
  "$id": "DateTimeOffset.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "localDateTime": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DateTimeOffset_LocalEpochMs"
        },
        {
          "$ref": "#/definitions/DateTimeOffset_DateTimeComponents"
        }
      ],
      "default": null
    },
    "timeOffset": {
      "oneOf": [
        {
          "type": "null"
        },
        {
          "$ref": "#/definitions/DateTimeOffset_UtcOffset"
        }
      ],
      "default": null
    }
  },
  "definitions": {
    "DateTimeOffset_LocalEpochMs": {
      "title": "DateTimeOffset_LocalEpochMs",
      "type": "object",
      "properties": {
        "kind": {
          "type": "string",
          "enum": [
            "local_epoch_ms"
          ],
          "default": "local_epoch_ms"
        },
        "value": {
          "title": "value",
          "type": "integer",
          "default": 0
        }
      }
    },
    "DateTimeOffset_DateTimeComponents": {
      "title": "DateTimeOffset_DateTimeComponents",
      "type": "object",
      "properties": {
        "kind": {
          "type": "string",
          "enum": [
            "date_time_components"
          ],
          "default": "date_time_components"
        },
        "value": {
          "$ref": "DateTimeComponents.json"
        }
      }
    },
    "DateTimeOffset_UtcOffset": {
      "title": "DateTimeOffset_UtcOffset",
      "type": "object",
      "properties": {
        "kind": {
          "type": "string",
          "enum": [
            "utc_offset"
          ],
          "default": "utc_offset"
        },
        "value": {
          "title": "value",
          "type": "integer",
          "default": 0
        }
      }
    }
  }
}
```