### PR TITLE
separate out subschemas

### DIFF
--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -292,11 +292,6 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 				subSchema.Value.Schema = nil
 				subSchema.Name = messageDefinitionName(subMessage.Desc)
 
-				//if subSchema.Value.Definitions != nil {
-				//	*schema.Value.Definitions = append(*schema.Value.Definitions, *subSchema.Value.Definitions...)
-				//	subSchema.Value.Definitions = nil
-				//}
-
 				schemas = append(schemas, subSchemas...)
 			}
 		}

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -260,7 +260,7 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 
 	// For each message, generate a schema.
 	for _, message := range messages {
-		schemaName := string(message.Desc.Name())
+		schemaName := messageDefinitionName(message.Desc)
 		typ := "object"
 		id := fmt.Sprintf("%s%s.json", *g.conf.BaseURL, schemaName)
 
@@ -284,14 +284,6 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 		if message.Messages != nil {
 			for _, subMessage := range message.Messages {
 				subSchemas := g.buildSchemasFromMessages([]*protogen.Message{subMessage})
-				if len(subSchemas) != 1 {
-					continue
-				}
-				subSchema := subSchemas[0]
-				subSchema.Value.ID = nil
-				subSchema.Value.Schema = nil
-				subSchema.Name = messageDefinitionName(subMessage.Desc)
-
 				schemas = append(schemas, subSchemas...)
 			}
 		}

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -177,7 +177,7 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForType(desc protoreflect.Message
 	}
 
 	typeName = messageDefinitionName(desc)
-	ref := "#/definitions/" + g.formatMessageNameString(typeName)
+	ref := g.formatMessageNameString(typeName) + ".json"
 	return &jsonschema.Schema{Ref: &ref}
 }
 
@@ -202,14 +202,6 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 		kindSchema = g.schemaOrReferenceForType(field.Message())
 		if kindSchema == nil {
 			return nil
-		}
-
-		if kindSchema.Ref != nil {
-			if !refInDefinitions(*kindSchema.Ref, definitions) {
-				ref := strings.Replace(*kindSchema.Ref, "#/definitions/", *g.conf.BaseURL, 1)
-				ref += ".json"
-				kindSchema.Ref = &ref
-			}
 		}
 
 	case protoreflect.StringKind:
@@ -288,12 +280,8 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 			schema.Value.Description = &description
 		}
 
-		// Any embedded messages will be created as definitions
+		// Any embedded messages will be created as new schemas
 		if message.Messages != nil {
-			if schema.Value.Definitions == nil {
-				schema.Value.Definitions = &[]*jsonschema.NamedSchema{}
-			}
-
 			for _, subMessage := range message.Messages {
 				subSchemas := g.buildSchemasFromMessages([]*protogen.Message{subMessage})
 				if len(subSchemas) != 1 {
@@ -304,12 +292,12 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 				subSchema.Value.Schema = nil
 				subSchema.Name = messageDefinitionName(subMessage.Desc)
 
-				if subSchema.Value.Definitions != nil {
-					*schema.Value.Definitions = append(*schema.Value.Definitions, *subSchema.Value.Definitions...)
-					subSchema.Value.Definitions = nil
-				}
+				//if subSchema.Value.Definitions != nil {
+				//	*schema.Value.Definitions = append(*schema.Value.Definitions, *subSchema.Value.Definitions...)
+				//	subSchema.Value.Definitions = nil
+				//}
 
-				*schema.Value.Definitions = append(*schema.Value.Definitions, subSchemas...)
+				schemas = append(schemas, subSchemas...)
 			}
 		}
 
@@ -382,17 +370,4 @@ func getSchemaVersion(schema *jsonschema.Schema) string {
 		return matches[1]
 	}
 	return ""
-}
-
-func refInDefinitions(ref string, definitions *[]*jsonschema.NamedSchema) bool {
-	if definitions == nil {
-		return false
-	}
-	ref = strings.TrimPrefix(ref, "#/definitions/")
-	for _, def := range *definitions {
-		if ref == def.Name {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
The way the current `protoc-gen-jsonschema` plugin works, subschemas are contained under the `definitions` in a JSON schema. For example, the following proto:

```proto
message OuterMessage {
  message InnerMessage {
    string str = 1;
  }
}
```

translates to:

```json
{
  "title": "OuterMessage",
  "$id": "OuterMessage.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
  },
  "definitions": {
    "OuterMessage_InnerMessage": {
      "title": "OuterMessage_InnerMessage",
      "type": "object",
      "properties": {
        "str": {
          "title": "str",
          "type": "string"
        }
      }
    }
  }
}
```

However, this makes things difficult when another proto message references the subschema. For example, the following proto:

```proto
message AnotherMessage {
  OuterMessage.InnerMessage referenced_subschema = 1;
}
```

translates to:

```json
{
  "title": "AnotherMessage",
  "$id": "AnotherMessage.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "referencedSubschema": {
      "$ref": "OuterMessage_InnerMessage.json"
    }
  }
}
```

This does not work as-is, since as-is there is no `OuterMessage_InnerMessage.json` file that is generated, but rather the definition of `OuterMessage_InnerMessage` is contained in `OuterMessage.json`. This PR changes it so that instead a separate JSON file will be generated for `OuterMessage_InnerMessage`.