### PR TITLE
default values

### DIFF
--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -292,11 +292,6 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 				subSchema.Value.Schema = nil
 				subSchema.Name = messageDefinitionName(subMessage.Desc)
 
-				//if subSchema.Value.Definitions != nil {
-				//	*schema.Value.Definitions = append(*schema.Value.Definitions, *subSchema.Value.Definitions...)
-				//	subSchema.Value.Definitions = nil
-				//}
-
 				schemas = append(schemas, subSchemas...)
 			}
 		}

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -260,7 +260,7 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 
 	// For each message, generate a schema.
 	for _, message := range messages {
-		schemaName := string(message.Desc.Name())
+		schemaName := messageDefinitionName(message.Desc)
 		typ := "object"
 		id := fmt.Sprintf("%s%s.json", *g.conf.BaseURL, schemaName)
 
@@ -284,14 +284,6 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 		if message.Messages != nil {
 			for _, subMessage := range message.Messages {
 				subSchemas := g.buildSchemasFromMessages([]*protogen.Message{subMessage})
-				if len(subSchemas) != 1 {
-					continue
-				}
-				subSchema := subSchemas[0]
-				subSchema.Value.ID = nil
-				subSchema.Value.Schema = nil
-				subSchema.Name = messageDefinitionName(subMessage.Desc)
-
 				schemas = append(schemas, subSchemas...)
 			}
 		}

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -230,7 +230,7 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 				name := string(field.Enum().Values().Get(i).Name())
 				*kindSchema.Enumeration = append(*kindSchema.Enumeration, jsonschema.SchemaEnumValue{String: &name})
 				if i == 0 {
-					kindSchema.Default = &jsonschema.DefaultValue{StringValue: &emptyString}
+					kindSchema.Default = &jsonschema.DefaultValue{StringValue: &name}
 				}
 			}
 		} else {

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/compiler/protogen"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"gopkg.in/yaml.v3"
 
 	"github.com/google/gnostic/jsonschema"
 )
@@ -46,6 +47,7 @@ var (
 	emptyInt64   = int64(0)
 	emptyFloat64 = 0.0
 	emptyBoolean = false
+	emptyArray   = []*yaml.Node{}
 )
 
 func init() {
@@ -227,9 +229,13 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 			for i := 0; i < field.Enum().Values().Len(); i++ {
 				name := string(field.Enum().Values().Get(i).Name())
 				*kindSchema.Enumeration = append(*kindSchema.Enumeration, jsonschema.SchemaEnumValue{String: &name})
+				if i == 0 {
+					kindSchema.Default = &jsonschema.DefaultValue{StringValue: &emptyString}
+				}
 			}
 		} else {
 			kindSchema.Type = &jsonschema.StringOrStringArray{String: &typeInteger}
+			kindSchema.Default = &jsonschema.DefaultValue{Int64Value: &emptyInt64}
 		}
 
 	case protoreflect.BoolKind:
@@ -253,6 +259,7 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 			Items: &jsonschema.SchemaOrSchemaArray{
 				Schema: kindSchema,
 			},
+			Default: &jsonschema.DefaultValue{ArrayValue: emptyArray},
 		}
 	}
 

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -177,7 +177,7 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForType(desc protoreflect.Message
 	}
 
 	typeName = messageDefinitionName(desc)
-	ref := "#/definitions/" + g.formatMessageNameString(typeName)
+	ref := g.formatMessageNameString(typeName) + ".json"
 	return &jsonschema.Schema{Ref: &ref}
 }
 
@@ -202,14 +202,6 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 		kindSchema = g.schemaOrReferenceForType(field.Message())
 		if kindSchema == nil {
 			return nil
-		}
-
-		if kindSchema.Ref != nil {
-			if !refInDefinitions(*kindSchema.Ref, definitions) {
-				ref := strings.Replace(*kindSchema.Ref, "#/definitions/", *g.conf.BaseURL, 1)
-				ref += ".json"
-				kindSchema.Ref = &ref
-			}
 		}
 
 	case protoreflect.StringKind:
@@ -288,12 +280,8 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 			schema.Value.Description = &description
 		}
 
-		// Any embedded messages will be created as definitions
+		// Any embedded messages will be created as new schemas
 		if message.Messages != nil {
-			if schema.Value.Definitions == nil {
-				schema.Value.Definitions = &[]*jsonschema.NamedSchema{}
-			}
-
 			for _, subMessage := range message.Messages {
 				subSchemas := g.buildSchemasFromMessages([]*protogen.Message{subMessage})
 				if len(subSchemas) != 1 {
@@ -304,12 +292,12 @@ func (g *JSONSchemaGenerator) buildSchemasFromMessages(messages []*protogen.Mess
 				subSchema.Value.Schema = nil
 				subSchema.Name = messageDefinitionName(subMessage.Desc)
 
-				if subSchema.Value.Definitions != nil {
-					*schema.Value.Definitions = append(*schema.Value.Definitions, *subSchema.Value.Definitions...)
-					subSchema.Value.Definitions = nil
-				}
+				//if subSchema.Value.Definitions != nil {
+				//	*schema.Value.Definitions = append(*schema.Value.Definitions, *subSchema.Value.Definitions...)
+				//	subSchema.Value.Definitions = nil
+				//}
 
-				*schema.Value.Definitions = append(*schema.Value.Definitions, subSchemas...)
+				schemas = append(schemas, subSchemas...)
 			}
 		}
 
@@ -382,17 +370,4 @@ func getSchemaVersion(schema *jsonschema.Schema) string {
 		return matches[1]
 	}
 	return ""
-}
-
-func refInDefinitions(ref string, definitions *[]*jsonschema.NamedSchema) bool {
-	if definitions == nil {
-		return false
-	}
-	ref = strings.TrimPrefix(ref, "#/definitions/")
-	for _, def := range *definitions {
-		if ref == def.Name {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/protoc-gen-jsonschema/generator/json-schema.go
+++ b/cmd/protoc-gen-jsonschema/generator/json-schema.go
@@ -41,6 +41,11 @@ var (
 	formatDateTime = "date-time"
 	formatEnum     = "enum"
 	formatBytes    = "bytes"
+
+	emptyString  = ""
+	emptyInt64   = int64(0)
+	emptyFloat64 = 0.0
+	emptyBoolean = false
 )
 
 func init() {
@@ -205,14 +210,14 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 		}
 
 	case protoreflect.StringKind:
-		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeString}}
+		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeString}, Default: &jsonschema.DefaultValue{StringValue: &emptyString}}
 
 	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Uint32Kind,
 		protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
 		protoreflect.Sfixed32Kind, protoreflect.Fixed32Kind, protoreflect.Sfixed64Kind,
 		protoreflect.Fixed64Kind:
 		format := kind.String()
-		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeInteger}, Format: &format}
+		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeInteger}, Format: &format, Default: &jsonschema.DefaultValue{Int64Value: &emptyInt64}}
 
 	case protoreflect.EnumKind:
 		kindSchema = &jsonschema.Schema{Format: &formatEnum}
@@ -228,14 +233,14 @@ func (g *JSONSchemaGenerator) schemaOrReferenceForField(field protoreflect.Field
 		}
 
 	case protoreflect.BoolKind:
-		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeBoolean}}
+		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeBoolean}, Default: &jsonschema.DefaultValue{BooleanValue: &emptyBoolean}}
 
 	case protoreflect.FloatKind, protoreflect.DoubleKind:
 		format := kind.String()
-		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeNumber}, Format: &format}
+		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeNumber}, Format: &format, Default: &jsonschema.DefaultValue{Float64Value: &emptyFloat64}}
 
 	case protoreflect.BytesKind:
-		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeString}, Format: &formatBytes}
+		kindSchema = &jsonschema.Schema{Type: &jsonschema.StringOrStringArray{String: &typeString}, Format: &formatBytes, Default: &jsonschema.DefaultValue{StringValue: &emptyString}}
 
 	default:
 		log.Printf("(TODO) Unsupported field type: %+v", field.Message().FullName())

--- a/jsonschema/models.go
+++ b/jsonschema/models.go
@@ -16,8 +16,6 @@
 // of JSON Schemas.
 package jsonschema
 
-import "gopkg.in/yaml.v3"
-
 // The Schema struct models a JSON Schema and, because schemas are
 // defined hierarchically, contains many references to itself.
 // All fields are pointers and are nil if the associated values
@@ -70,7 +68,7 @@ type Schema struct {
 	// 6.  Metadata keywords
 	Title       *string
 	Description *string
-	Default     *yaml.Node
+	Default     *DefaultValue
 
 	// 7.  Semantic validation with "format"
 	Format *string
@@ -227,4 +225,11 @@ func (s *Schema) DefinitionWithName(name string) *Schema {
 // AddProperty adds a named property.
 func (s *Schema) AddProperty(name string, property *Schema) {
 	*s.Properties = append(*s.Properties, NewNamedSchema(name, property))
+}
+
+type DefaultValue struct {
+	StringValue  *string
+	BooleanValue *bool
+	Int64Value   *int64
+	Float64Value *float64
 }

--- a/jsonschema/models.go
+++ b/jsonschema/models.go
@@ -16,6 +16,8 @@
 // of JSON Schemas.
 package jsonschema
 
+import "gopkg.in/yaml.v3"
+
 // The Schema struct models a JSON Schema and, because schemas are
 // defined hierarchically, contains many references to itself.
 // All fields are pointers and are nil if the associated values
@@ -232,4 +234,5 @@ type DefaultValue struct {
 	BooleanValue *bool
 	Int64Value   *int64
 	Float64Value *float64
+	ArrayValue   []*yaml.Node
 }

--- a/jsonschema/reader.go
+++ b/jsonschema/reader.go
@@ -143,7 +143,7 @@ func NewSchemaFromObject(jsonData *yaml.Node) *Schema {
 				schema.Description = schema.stringValue(v)
 
 			case "default":
-				schema.Default = v
+				schema.Default = schema.defaultValue(v)
 
 			case "format":
 				schema.Format = schema.stringValue(v)
@@ -244,6 +244,28 @@ func (schema *Schema) boolValue(v *yaml.Node) *bool {
 		}
 	default:
 		fmt.Printf("boolValue: unexpected node %+v\n", v)
+	}
+	return nil
+}
+
+func (schema *Schema) defaultValue(v *yaml.Node) *DefaultValue {
+	switch v.Kind {
+	case yaml.ScalarNode:
+		switch v.Tag {
+		case "!!float":
+			v2, _ := strconv.ParseFloat(v.Value, 64)
+			return &DefaultValue{Float64Value: &v2}
+		case "!!int":
+			v2, _ := strconv.ParseInt(v.Value, 10, 64)
+			return &DefaultValue{Int64Value: &v2}
+		case "!!bool":
+			v2, _ := strconv.ParseBool(v.Value)
+			return &DefaultValue{BooleanValue: &v2}
+		default:
+			return &DefaultValue{StringValue: &v.Value}
+		}
+	default:
+		fmt.Printf("defaultValue: unexpected node %+v\n", v)
 	}
 	return nil
 }

--- a/jsonschema/reader.go
+++ b/jsonschema/reader.go
@@ -264,6 +264,8 @@ func (schema *Schema) defaultValue(v *yaml.Node) *DefaultValue {
 		default:
 			return &DefaultValue{StringValue: &v.Value}
 		}
+	case yaml.SequenceNode:
+		return &DefaultValue{ArrayValue: v.Content}
 	default:
 		fmt.Printf("defaultValue: unexpected node %+v\n", v)
 	}

--- a/jsonschema/writer.go
+++ b/jsonschema/writer.go
@@ -385,6 +385,8 @@ func (schema *Schema) nodeValue() *yaml.Node {
 			content = appendPair(content, "default", nodeForInt64(*schema.Default.Int64Value))
 		} else if schema.Default.Float64Value != nil {
 			content = appendPair(content, "default", nodeForFloat64(*schema.Default.Float64Value))
+		} else if schema.Default.ArrayValue != nil {
+			content = appendPair(content, "default", nodeForSequence(schema.Default.ArrayValue))
 		}
 	}
 	if schema.Format != nil {

--- a/jsonschema/writer.go
+++ b/jsonschema/writer.go
@@ -34,7 +34,7 @@ func renderMappingNode(node *yaml.Node, indent string) (result string) {
 		value := node.Content[i+1]
 		switch value.Kind {
 		case yaml.ScalarNode:
-			if value.Tag == "!!bool" {
+			if value.Tag == "!!bool" || value.Tag == "!!int" || value.Tag == "!!float" {
 				result += value.Value
 			} else {
 				result += "\"" + value.Value + "\""
@@ -377,7 +377,15 @@ func (schema *Schema) nodeValue() *yaml.Node {
 		content = appendPair(content, "definitions", nodeForNamedSchemaArray(schema.Definitions))
 	}
 	if schema.Default != nil {
-		// m = append(m, yaml.MapItem{Key: "default", Value: *schema.Default})
+		if schema.Default.StringValue != nil {
+			content = appendPair(content, "default", nodeForString(*schema.Default.StringValue))
+		} else if schema.Default.BooleanValue != nil {
+			content = appendPair(content, "default", nodeForBoolean(*schema.Default.BooleanValue))
+		} else if schema.Default.Int64Value != nil {
+			content = appendPair(content, "default", nodeForInt64(*schema.Default.Int64Value))
+		} else if schema.Default.Float64Value != nil {
+			content = appendPair(content, "default", nodeForFloat64(*schema.Default.Float64Value))
+		}
 	}
 	if schema.Format != nil {
 		content = appendPair(content, "format", nodeForString(*schema.Format))


### PR DESCRIPTION
**To be merged after https://github.com/CamBDignan/gnostic/pull/2**

This change is for adding default values to the JSON schemas. The defaults match standard protobuf defaults (0 for int, "" for string, false for bool, etc.).

For example, the following proto:

```proto
message StrMessage {
  string str_field = 1;
}
```

translates to the following JSON schema:

```json
{
  "title": "StrMessage",
  "$id": "StrMessage.json",
  "$schema": "http://json-schema.org/draft-07/schema#",
  "type": "object",
  "properties": {
    "strField ": {
      "title": "strField",
      "type": "string",
      "default": "" // this is new
    }
  }
}
```

Default values aren't generally really needed in JSON schema as they only describe behavior, not valid inputs or outputs. However, the reason why it is useful is because some code generators will use these defaults in useful ways. For example, the `datamodel-code-generator` for generating Python Pydantic classes (https://github.com/koxudaxi/datamodel-code-generator) has a flag `--strict-nullable` which means treat default fields as non-nullable. In other words, rather than generating the following Pydantic class:

```python
class StrMessage(BaseModel):
  strField: Optional[str] = None
```

the following Pydantic class will be generated instead:

```python
class StrMessage(BaseModel):
  strField: str = ""
```

I would argue that the latter Pydantic class is closer in spirit to the corresponding proto message. Therefore, I believe that this change to add defaults to the JSON schema is worthwhile.